### PR TITLE
Issue10 expose end function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             npm run lint
   release:
     docker:
-      - image: circleci/node:8.16.0
+      - image: circleci/node:12.16.2
     working_directory: ~/repo
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.16.0
+      - image: circleci/node:12.16.2
     working_directory: ~/repo
     steps:
       - checkout

--- a/src/sftp/sftp-client/sftp-client.service.ts
+++ b/src/sftp/sftp-client/sftp-client.service.ts
@@ -13,12 +13,20 @@ export class SftpClientService {
   }
 
   /**
-   * Sets the sftp connection, updates/creates the connection used in initialization.
+   * Resets the sftp connection, updates/creates the connection used in initialization.
    *
    * @param config
    */
   async resetConnection(config: ConnectConfig): Promise<void> {
+    await this.sftpClient.end();
     await this.sftpClient.connect(config);
+  }
+
+  /**
+   * Closes the current connection.
+   */
+  async disconnect() {
+    await this.sftpClient.end();
   }
 
   async upload(


### PR DESCRIPTION
Issue #10 expose the `.end()` to allow ssh to disconnect and reconnect. Otherwise it will error with

> {
>     "errorType": "Error",
>     "errorMessage": "connect: An existing SFTP connection is already defined",
>     "code": "ERR_NOT_CONNECTED",
>     "custom": true,
>     "stack": [
>         "Error: connect: An existing SFTP connection is already defined",
>         "    at Object.formatError (/var/task/node_modules/ssh2-sftp-client/src/utils.js:62:18)",
>         "    at Promise (/var/task/node_modules/ssh2-sftp-client/src/index.js:140:17)",
>         "    at new Promise (<anonymous>)",
>         "    at SftpClient.connect (/var/task/node_modules/ssh2-sftp-client/src/index.js:137:12)",
>         "    at SftpClientService.resetConnection (/var/task/node_modules/nest-sftp/dist/sftp/sftp-client/sftp-client.service.js:21:31)",
>         "    at AcxiomService.processAcxiomFileSubmission (/var/task/dist/acxiom/axciom.service.js:38:31)",
>         "    at process._tickCallback (internal/process/next_tick.js:68:7)"
>     ]
> }